### PR TITLE
doubled RGB->GRB fix

### DIFF
--- a/src/Nano_Every_WS2812B.cpp
+++ b/src/Nano_Every_WS2812B.cpp
@@ -72,7 +72,7 @@ void CI_WS2812B::write_string(int number_of_leds, ci_ws2812b_rgb_t led_data[])
   for (int i=0; i<number_of_leds; i++)
   {
     // Transmit 24-bit RGB color data 8 bits at a time.
-    write(led_data[i].g,led_data[i].r,led_data[i].b);
+    write(led_data[i].r,led_data[i].g,led_data[i].b); // note: write() function will transmit data in (g,r,b) order
   }
   sei();
   delayMicroseconds(100); // Latch the data.


### PR DESCRIPTION
First of all, nice library, thank you for taking the time to do the low level register stuff, it's saved me some frustration :).

I noticed that in the write_string function, you pass the contents of the RGB struct in GRB order to the write(R,G,B) function:
https://github.com/ClemensAtElektor/Nano_Every_WS2812B/blob/832af0a08d6406ec57d1615bc36a099a41f9a519/src/Nano_Every_WS2812B.cpp#L75
isn't this a double re-ordering (because the write() function expects (r,g,b) input, and writes the data as (g,r,b) to the LED):
https://github.com/ClemensAtElektor/Nano_Every_WS2812B/blob/832af0a08d6406ec57d1615bc36a099a41f9a519/src/Nano_Every_WS2812B.cpp#L62-L67
